### PR TITLE
Fix local cluster script path usage

### DIFF
--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -15,10 +15,11 @@ This directory contains Docker Compose configuration for running the A2A demo ap
 2. **Start the services:**
 
    ```bash
-   docker-compose up -d
+   ./run-local-cluster.sh
    ```
 
-   This will start the UI and agent services in the background.
+   Run this script from anywhere (e.g. `deploy/local/run-local-cluster.sh` from the
+   repo root). It builds the images and starts the services in the background.
 
 3. **Access the UI:**
 

--- a/deploy/local/run-local-cluster.sh
+++ b/deploy/local/run-local-cluster.sh
@@ -3,6 +3,8 @@
 # Quick script to run the A2A local cluster with Docker Compose
 # Created by Claude
 
+cd "$(dirname "$0")"
+
 echo "Starting A2A local cluster..."
 
 # Check if .env exists


### PR DESCRIPTION
## Summary
- ensure `run-local-cluster.sh` runs from its own directory
- update docs to run the script for local startup

## Testing
- `ruff check .`
- `uv run pytest -v -s test_a2a_spec.py` *(fails: No route to host)*