### PR TITLE
Fix port comment

### DIFF
--- a/deploy/local/.env.template
+++ b/deploy/local/.env.template
@@ -19,5 +19,5 @@ A2A_PERSISTENCE=TRUE
 # Port assignments for agents
 # These match the ports in docker-compose.yaml and Kubernetes manifests
 # google_adk: 10002
-# elevenlabs_tts: 10003
+# elevenlabs_tts: 10005
 # vertex_image_gen: 10006


### PR DESCRIPTION
## Summary
- change port comment to match manifests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest` *(fails: command not found)*