### PR TITLE
Update agent placeholder and Tilt docs

### DIFF
--- a/README_TILT.md
+++ b/README_TILT.md
@@ -51,6 +51,8 @@ After the UI and agents are running, go to the "Remote Agents" tab in the UI and
 - agent-elevenlabs-tts:10005
 - agent-vertex-image-gen:10006
 
+When running via Tilt, use the container service names (e.g., `agent-google-adk`) rather than `localhost` for agent addresses.
+
 ## Customizing Tilt Behavior
 
 Edit the `Tiltfile` to customize the development workflow:

--- a/demo/ui/pages/agent_list.py
+++ b/demo/ui/pages/agent_list.py
@@ -30,7 +30,7 @@ def agent_list_page(app_state: AppState):
                     me.input(
                         label='Agent Address',
                         on_blur=set_agent_address,
-                        placeholder='localhost:10000',
+                        placeholder='agent-google-adk:10002',
                     )
                     input_modes_string = ', '.join(state.input_modes)
                     output_modes_string = ', '.join(state.output_modes)


### PR DESCRIPTION
## Summary
- use container service address in agent list placeholder
- remind Tilt users to use container service names for agent addresses

## Testing
- `ruff check demo/ui/pages/agent_list.py` *(fails: D415 etc.)*