### PR TITLE
Optimize local dev rebuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Exclude version control and config files
+.git
+.github
+*.md
+*.toml
+*.lock
+noxfile.py
+docs/
+tests/
+**/__pycache__/
+**/*.pyc

--- a/.tiltignore
+++ b/.tiltignore
@@ -1,0 +1,4 @@
+# Ignore docs and test directories to prevent unnecessary rebuilds
+./docs
+./tests
+*.md

--- a/Tiltfile.simple
+++ b/Tiltfile.simple
@@ -1,2 +1,7 @@
 # Minimal Tiltfile for A2A demo
+
+# Load environment variables from .env so Tilt uses the same values as Docker Compose
+load('tilt_modules/dotenv/Tiltfile', 'dotenv')
+dotenv('.env')
+
 docker_compose('./deploy/local/docker-compose.yaml')

--- a/deploy/local/README.md
+++ b/deploy/local/README.md
@@ -19,7 +19,8 @@ This directory contains Docker Compose configuration for running the A2A demo ap
    ```
 
    Run this script from anywhere (e.g. `deploy/local/run-local-cluster.sh` from the
-   repo root). It builds the images and starts the services in the background.
+   repo root). It reuses cached Docker layers and only rebuilds images when sources
+   have changed.
 
 3. **Access the UI:**
 

--- a/deploy/local/run-local-cluster.sh
+++ b/deploy/local/run-local-cluster.sh
@@ -18,9 +18,9 @@ fi
 echo "Cleaning up any previous containers..."
 docker compose down --volumes
 
-# Rebuild all images from scratch (to ensure recent code changes are captured)
-echo "Building fresh images..."
-docker compose build --no-cache
+# Build images only when sources have changed
+echo "Building images if needed..."
+docker compose build
 
 # Start services
 echo "Starting services..."


### PR DESCRIPTION
## Summary
- ensure Tilt uses env vars from `.env`
- avoid full image rebuilds in the helper script
- document image caching in the local deployment guide
- ignore docs/test files in Tilt and Docker builds

## Testing
- `python -m pip install -e samples/python` *(fails: Could not find hatchling)*
- `pytest` *(fails: command not found)*